### PR TITLE
stick to well-known deps version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ readme = "README.md"
 description = "A web version of Just One"
 
 [dependencies]
-warp = { version = "*", features = ["tls"] }
-tokio = { version = "*", features = ["full", "io-util", "io-std", "sync"] }
-futures = "*"
-log = "*"
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
-rand = "*"
-clap = "*"
-slog = "*"
-slog-term = "*"
-slog-async = "*"
-slog-scope = "*"
+warp = { version = "0.2", features = ["tls"] }
+tokio = { version = "0.2", features = ["full", "io-util", "io-std", "sync"] }
+futures = "0.3"
+log = "0.4"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+rand = "0.7"
+clap = "2.33"
+slog = "2.5"
+slog-term = "2.6"
+slog-async = "2.5"
+slog-scope = "4.3"


### PR DESCRIPTION
Best to stick to major versions of dependencies so build does not
actually break when they change their API.
For example, it's currently broken when using tokio 0.3 and our deps
are still relying on tokio 0.2 anyway.